### PR TITLE
chore: Adds sdcore-user-plane (Machine Charm) module

### DIFF
--- a/modules/sdcore-control-plane-k8s/README.md
+++ b/modules/sdcore-control-plane-k8s/README.md
@@ -87,7 +87,7 @@ terraform apply -var-file="terraform.tfvars" -auto-approve
 
 #### Including Canonical Observability Stack (COS)
 
-The `sdcore-k8s` Terraform module offers an option to automatically deploy COS. To use it,
+The `sdcore-control-plane-k8s` Terraform module offers an option to automatically deploy COS. To use it,
 add following variable to your `terraform.tfvars`:
 
 ```text

--- a/modules/sdcore-k8s/variables.tf
+++ b/modules/sdcore-k8s/variables.tf
@@ -4,7 +4,7 @@
 variable "model_name" {
   description = "Name of Juju model to deploy application to."
   type        = string
-  default     = ""
+  default     = "sdcore"
 }
 
 variable "create_model" {

--- a/modules/sdcore-user-plane-k8s/README.md
+++ b/modules/sdcore-user-plane-k8s/README.md
@@ -88,7 +88,7 @@ terraform apply -var-file="terraform.tfvars" -auto-approve
 
 #### Including Canonical Observability Stack (COS)
 
-The `sdcore-k8s` Terraform module offers an option to automatically deploy COS. To use it,
+The `sdcore-user-plane-k8s` Terraform module offers an option to automatically deploy COS. To use it,
 add following variable to your `terraform.tfvars`:
 
 ```text

--- a/modules/sdcore-user-plane/README.md
+++ b/modules/sdcore-user-plane/README.md
@@ -1,0 +1,110 @@
+# SD-Core User Plane Terraform Module
+
+This folder contains the [Terraform][Terraform] module to deploy the SD-Core User Plane.
+
+The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm deployment onto any Kubernetes environment managed by [Juju][Juju].
+
+The module can be used to deploy the `sdcore-user-plane` separately as well as a part of the higher level modules, depending on the deployment architecture.
+
+## Module structure
+
+- **main.tf** - Defines the Juju application to be deployed.
+- **variables.tf** - Allows customization of the deployment including Juju model name, charm's channel and configuration.
+- **output.tf** - Responsible for integrating the module with other Terraform modules, primarily by defining potential integration endpoints (charm integrations).
+- **terraform.tf** - Defines the Terraform provider.
+
+## Deploying sdcore-user-plane module separately
+
+### Pre-requisites
+
+- A UPF host which meets or exceeds below requirements:
+  - Ubuntu 24.04
+  - CPU supporting AVX2 and RDRAND instructions (Intel Haswell, AMD Excavator or equivalent)
+- Juju host
+  - Juju>=3.4
+- Terraform
+
+### Preparing deployment environment
+
+Install Juju:
+
+```shell
+sudo snap install juju --channel=3.4/stable
+```
+
+Create `manual` cloud on Juju host: 
+
+```shell
+cat << EOF > user-plane-cloud.yaml
+clouds:
+  user-plane-cloud:
+    type: manual
+EOF
+juju add-cloud user-plane-cloud -f user-plane-cloud.yaml
+juju bootstrap manual/<YOUR HOST NAME> sdcore-user-plane
+```
+
+Create Juju model:
+
+```shell
+juju add-model user-plane
+```
+
+Add UPF host to the model:
+
+```shell
+juju add-machine ssh:<USERNAME>@<JUJU HOST NAME> --private-key <PATH TO THE SSH PRIVATE KEY>
+```
+
+### Deploying sdcore-user-plane with Terraform
+
+Initialize the provider:
+
+```console
+terraform init
+```
+
+Create the `terraform.tfvars` file to specify the name of the Juju model to deploy to. Reusing already existing model is not recommended.
+
+```console
+cat << EOF | tee terraform.tfvars
+model_name = "put your model-name here"
+
+# Customize the configuration variables here if needed
+EOF
+```
+
+Deploy the resources:
+
+```console
+terraform apply -var-file="terraform.tfvars" -auto-approve 
+```
+
+#### Including Canonical Observability Stack (COS)
+
+The `sdcore-user-plane` doesn't currently support integration with COS.
+
+### Cleaning up
+
+Destroy the deployment:
+
+```console
+terraform destroy -auto-approve
+```
+
+## Using sdcore-user-plane module in higher level modules
+
+If you want to use `sdcore-user-plane` module as part of your Terraform module, import it like shown below:
+
+```text
+module "sdcore-user-plane" {
+  source = "git::https://github.com/canonical/https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane"
+  
+  model_name = "juju_model_name"
+  (Customize configuration variables here if needed)
+}
+```
+
+[Terraform]: https://www.terraform.io/
+[Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest
+[Juju]: https://juju.is

--- a/modules/sdcore-user-plane/main.tf
+++ b/modules/sdcore-user-plane/main.tf
@@ -1,0 +1,16 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_model" "sdcore" {
+  count = var.create_model == true ? 1 : 0
+  name  = var.model_name
+}
+
+module "upf" {
+  source         = "git::https://github.com/canonical/sdcore-upf-operator//terraform"
+  model_name     = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
+  channel        = var.upf_channel
+  base           = "ubuntu@24.04"
+  config         = var.upf_config
+  machine_number = var.machine_number
+}

--- a/modules/sdcore-user-plane/outputs.tf
+++ b/modules/sdcore-user-plane/outputs.tf
@@ -1,0 +1,17 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "upf_app_name" {
+  description = "Name of the deployed UPF application."
+  value       = module.upf.app_name
+}
+
+output "fiveg_n3_endpoint" {
+  description = "Name of the endpoint used to provide information on connectivity to the N3 plane."
+  value       = module.upf.fiveg_n3_endpoint
+}
+
+output "fiveg_n4_endpoint" {
+  description = "Name of the endpoint used to provide information on connectivity to the N4 plane."
+  value       = module.upf.fiveg_n4_endpoint
+}

--- a/modules/sdcore-user-plane/terraform.tf
+++ b/modules/sdcore-user-plane/terraform.tf
@@ -1,0 +1,11 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.11.0"
+    }
+  }
+}

--- a/modules/sdcore-user-plane/terraform.tf
+++ b/modules/sdcore-user-plane/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.11.0"
+      version = ">= 0.12.0"
     }
   }
 }

--- a/modules/sdcore-user-plane/variables.tf
+++ b/modules/sdcore-user-plane/variables.tf
@@ -1,0 +1,32 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "model_name" {
+  description = "Name of Juju model to deploy application to."
+  type        = string
+  default     = ""
+}
+
+variable "create_model" {
+  description = "Allows to skip Juju model creation and re-use a model created in a higher level module."
+  type        = bool
+  default     = true
+}
+
+variable "upf_channel" {
+  description = "The channel to use when deploying `sdcore-upf` charm."
+  type        = string
+  default     = "1.4/edge"
+}
+
+variable "machine_number" {
+  description = "The machine unit number to use for placement."
+  type        = number
+  default     = 0
+}
+
+variable "upf_config" {
+  description = "Application config for the UPF. Details about available options can be found at https://charmhub.io/sdcore-upf-operator/configure."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
# Description

This PR adds a root module for the Machine Charm based User Plane.

This PR depends on [changes in the UPF operator](https://github.com/canonical/sdcore-upf-operator/pull/112)

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library