### PR TITLE
fix: Changes fixed version of the Terraform provider for Observability modules to a range (>= 0.12.0)

### DIFF
--- a/modules/external/alertmanager-k8s/terraform.tf
+++ b/modules/external/alertmanager-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.12.0"
+      version = ">= 0.12.0"
     }
   }
 }

--- a/modules/external/catalogue-k8s/terraform.tf
+++ b/modules/external/catalogue-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.12.0"
+      version = ">= 0.12.0"
     }
   }
 }

--- a/modules/external/cos-configuration-k8s/terraform.tf
+++ b/modules/external/cos-configuration-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.12.0"
+      version = ">= 0.12.0"
     }
   }
 }

--- a/modules/external/grafana-agent-k8s/terraform.tf
+++ b/modules/external/grafana-agent-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.12.0"
+      version = ">= 0.12.0"
     }
   }
 }

--- a/modules/external/grafana-k8s/terraform.tf
+++ b/modules/external/grafana-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.12.0"
+      version = ">= 0.12.0"
     }
   }
 }

--- a/modules/external/loki-k8s/terraform.tf
+++ b/modules/external/loki-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.12.0"
+      version = ">= 0.12.0"
     }
   }
 }

--- a/modules/external/mongodb-k8s/terraform.tf
+++ b/modules/external/mongodb-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.12.0"
+      version = ">= 0.12.0"
     }
   }
 }

--- a/modules/external/prometheus-k8s/terraform.tf
+++ b/modules/external/prometheus-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.12.0"
+      version = ">= 0.12.0"
     }
   }
 }

--- a/modules/external/traefik-k8s/terraform.tf
+++ b/modules/external/traefik-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.12.0"
+      version = ">= 0.12.0"
     }
   }
 }


### PR DESCRIPTION
# Description

After `self-signed-certificates` bumped Juju Terraform provider version to 0.14.0 a conflict arised because Observability modules have been using 0.12.0. 
This PR allows Observability modules to use any version higher or equal than 0.12.0.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library