### PR TITLE
feat: add TLS integration to the NMS

### DIFF
--- a/modules/sdcore-control-plane-k8s/main.tf
+++ b/modules/sdcore-control-plane-k8s/main.tf
@@ -617,6 +617,20 @@ resource "juju_integration" "udr-certificates" {
   }
 }
 
+resource "juju_integration" "nms-certificates" {
+  model = data.juju_model.sdcore.name
+
+  application {
+    name     = module.nms.app_name
+    endpoint = module.nms.requires.certificates
+  }
+
+  application {
+    name     = module.self-signed-certificates.app_name
+    endpoint = module.self-signed-certificates.certificates_endpoint
+  }
+}
+
 # Integrations for `ingress` endpoint
 
 resource "juju_integration" "nms-ingress" {

--- a/modules/sdcore-control-plane-k8s/main.tf
+++ b/modules/sdcore-control-plane-k8s/main.tf
@@ -631,6 +631,20 @@ resource "juju_integration" "nms-certificates" {
   }
 }
 
+resource "juju_integration" "traefik-certificates" {
+  model = data.juju_model.sdcore.name
+
+  application {
+    name     = module.traefik.app_name
+    endpoint = module.traefik.requires.certificates
+  }
+
+  application {
+    name     = module.self-signed-certificates.app_name
+    endpoint = module.self-signed-certificates.certificates_endpoint
+  }
+}
+
 # Integrations for `ingress` endpoint
 
 resource "juju_integration" "nms-ingress" {

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -652,6 +652,20 @@ resource "juju_integration" "nms-certificates" {
   }
 }
 
+resource "juju_integration" "traefik-certificates" {
+  model = data.juju_model.sdcore.name
+
+  application {
+    name     = module.traefik.app_name
+    endpoint = module.traefik.requires.certificates
+  }
+
+  application {
+    name     = module.self-signed-certificates.app_name
+    endpoint = module.self-signed-certificates.certificates_endpoint
+  }
+}
+
 # Integrations for `ingress` endpoint
 
 resource "juju_integration" "nms-ingress" {

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -638,6 +638,20 @@ resource "juju_integration" "udr-certificates" {
   }
 }
 
+resource "juju_integration" "nms-certificates" {
+  model = data.juju_model.sdcore.name
+
+  application {
+    name     = module.nms.app_name
+    endpoint = module.nms.requires.certificates
+  }
+
+  application {
+    name     = module.self-signed-certificates.app_name
+    endpoint = module.self-signed-certificates.certificates_endpoint
+  }
+}
+
 # Integrations for `ingress` endpoint
 
 resource "juju_integration" "nms-ingress" {


### PR DESCRIPTION
# Description

This PR adds the TLS Certificates Integration to the NMS charm.
This integration is mandatory and the charm does not start the workload without it.
This integration is also added to traefik.

# Attention
Once traefik implements `certificate transfer` interface we'll be able to use that instead of integrating Traefik with self-signed-certificates.  https://github.com/canonical/traefik-k8s-operator/issues/407

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library