### PR TITLE
chore: use Juju 3.5 and Microk8s 1.31-strict/stable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 To make contributions to this repository, the following software is needed to be installed in your development environment. Please [set up your environment][set-up-environment] before development.
 
 - A Kubernetes cluster
-- Juju>=3.4
+- Juju>=3.5
 - Juju controller bootstrapped onto the K8s cluster
 - Terraform
 

--- a/modules/sdcore-control-plane-k8s/README.md
+++ b/modules/sdcore-control-plane-k8s/README.md
@@ -30,7 +30,7 @@ The following tools need to be installed and should be running in the environmen
 Install MicroK8s and add your user to the snap_microk8s group:
 
 ```shell
-sudo snap install microk8s --channel=1.29-strict/stable
+sudo snap install microk8s --channel=1.31-strict/stable
 sudo usermod -a -G snap_microk8s $USER
 newgrp snap_microk8s
 ```

--- a/modules/sdcore-control-plane-k8s/README.md
+++ b/modules/sdcore-control-plane-k8s/README.md
@@ -21,7 +21,7 @@ The following tools need to be installed and should be running in the environmen
 
 - A Kubernetes cluster with the `Multus` and `Metallb` addon enabled
 - The Load balancer (MetalLB) has address range with at least 2 available IP addresses
-- Juju>=3.4
+- Juju>=3.5
 - Juju controller bootstrapped onto the K8s cluster
 - Terraform
 
@@ -52,7 +52,7 @@ sudo microk8s enable metallb:10.0.0.2-10.0.0.3
 Install Juju:
 
 ```shell
-sudo snap install juju --channel=3.4/stable
+sudo snap install juju --channel=3.5/stable
 ```
 
 Bootstrap a Juju controller:
@@ -97,7 +97,7 @@ This will show an output similar to the following:
 
 ```console
 Model     Controller          Cloud/Region        Version  SLA          Timestamp
-<model_name>  microk8s-localhost  microk8s/localhost  3.4.0    unsupported  17:03:06+03:00
+<model_name>  microk8s-localhost  microk8s/localhost  3.5.4    unsupported  17:03:06+03:00
 
 App                       Version  Status   Scale  Charm                     Channel        Rev  Address         Exposed  Message
 amf                                active       1  sdcore-amf-k8s            1.5/edge        29  10.152.183.161  no       

--- a/modules/sdcore-k8s/README.md
+++ b/modules/sdcore-k8s/README.md
@@ -31,7 +31,7 @@ The following tools need to be installed and should be running in the environmen
 Install MicroK8s and add your user to the `snap_microk8s` group:
 
 ```shell
-sudo snap install microk8s --channel=1.29-strict/stable
+sudo snap install microk8s --channel=1.31-strict/stable
 sudo usermod -a -G snap_microk8s $USER
 newgrp snap_microk8s
 ```

--- a/modules/sdcore-k8s/README.md
+++ b/modules/sdcore-k8s/README.md
@@ -22,7 +22,7 @@ The following tools need to be installed and should be running in the environmen
 - A Kubernetes host with a CPU supporting AVX2 and RDRAND instructions (Intel Haswell, AMD Excavator or equivalent)
 - A Kubernetes cluster with the `Multus` and `Metallb` addon enabled.
 - The Load balancer (MetalLB) has address range with at least 3 available IP addresses
-- Juju 3.4
+- Juju 3.5
 - Juju controller bootstrapped onto the K8s cluster
 - Terraform
 
@@ -53,7 +53,7 @@ sudo microk8s enable metallb:10.0.0.2-10.0.0.4
 Install Juju:
 
 ```shell
-sudo snap install juju --channel=3.4/stable
+sudo snap install juju --channel=3.5/stable
 ```
 
 Bootstrap a Juju controller:
@@ -98,7 +98,7 @@ This will show an output similar to the following:
 
 ```console
 Model       Controller          Cloud/Region        Version  SLA          Timestamp
-<model_name>  microk8s-localhost  microk8s/localhost  3.4.0    unsupported  16:57:40+03:00
+<model_name>  microk8s-localhost  microk8s/localhost  3.5.4   unsupported  16:57:40+03:00
 
 App                       Version  Status   Scale  Charm                     Channel        Rev  Address         Exposed  Message
 amf                                active       1  sdcore-amf-k8s            1.5/edge        29  10.152.183.243  no       

--- a/modules/sdcore-user-plane-k8s/README.md
+++ b/modules/sdcore-user-plane-k8s/README.md
@@ -31,7 +31,7 @@ The following tools need to be installed and should be running in the environmen
 Install MicroK8s and add your user to the snap_microk8s group:
 
 ```shell
-sudo snap install microk8s --channel=1.29-strict/stable
+sudo snap install microk8s --channel=1.31-strict/stable
 sudo usermod -a -G snap_microk8s $USER
 newgrp snap_microk8s
 ```

--- a/modules/sdcore-user-plane-k8s/README.md
+++ b/modules/sdcore-user-plane-k8s/README.md
@@ -22,7 +22,7 @@ The following tools need to be installed and should be running in the environmen
 - A Kubernetes host with a CPU supporting AVX2 and RDRAND instructions (Intel Haswell, AMD Excavator or equivalent)
 - A Kubernetes cluster with the `Multus` and `Metallb` addon enabled.
 - The Load balancer (MetalLB) has address range with at least 1 available IP address
-- Juju>=3.4
+- Juju>=3.5
 - Juju controller bootstrapped onto the K8s cluster
 - Terraform
 
@@ -53,7 +53,7 @@ sudo microk8s enable metallb:10.0.0.2/32
 Install Juju:
 
 ```shell
-sudo snap install juju --channel=3.4/stable
+sudo snap install juju --channel=3.5/stable
 ```
 
 Bootstrap a Juju controller:
@@ -98,7 +98,7 @@ This will show an output similar to the following:
 
 ```console
 Model  Controller          Cloud/Region        Version  SLA          Timestamp
-<model_name>   microk8s-localhost  microk8s/localhost  3.4.0    unsupported  17:04:33+03:00
+<model_name>   microk8s-localhost  microk8s/localhost  3.5.4    unsupported  17:04:33+03:00
 
 App            Version  Status   Scale  Charm              Channel        Rev  Address         Exposed  Message
 grafana-agent  0.32.1   waiting      1  grafana-agent-k8s  latest/stable   51  10.152.183.231  no       installing agent

--- a/modules/sdcore-user-plane/README.md
+++ b/modules/sdcore-user-plane/README.md
@@ -21,7 +21,7 @@ The module can be used to deploy the `sdcore-user-plane` separately as well as a
   - Ubuntu 24.04
   - CPU supporting AVX2 and RDRAND instructions (Intel Haswell, AMD Excavator or equivalent)
 - Juju host
-  - Juju>=3.4
+  - Juju>=3.5
 - Terraform
 
 ### Preparing deployment environment
@@ -29,7 +29,7 @@ The module can be used to deploy the `sdcore-user-plane` separately as well as a
 Install Juju:
 
 ```shell
-sudo snap install juju --channel=3.4/stable
+sudo snap install juju --channel=3.5/stable
 ```
 
 Create `manual` cloud on Juju host: 


### PR DESCRIPTION
# Description

We decided to use Juju 3.5 and Microk8s 1.31-strict/stable  in SD-Core 1.5 channel. The reason why this PR updates the Juju and Microk8s versions in the documentation.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library