### PR TITLE
fix: traefik integration with certificates interface

### DIFF
--- a/modules/sdcore-control-plane-k8s/main.tf
+++ b/modules/sdcore-control-plane-k8s/main.tf
@@ -636,7 +636,7 @@ resource "juju_integration" "traefik-certificates" {
 
   application {
     name     = module.traefik.app_name
-    endpoint = module.traefik.requires.certificates
+    endpoint = module.traefik.certificates_endpoint
   }
 
   application {

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -657,7 +657,7 @@ resource "juju_integration" "traefik-certificates" {
 
   application {
     name     = module.traefik.app_name
-    endpoint = module.traefik.requires.certificates
+    endpoint = module.traefik.certificates_endpoint
   }
 
   application {


### PR DESCRIPTION
# Description

Traefik module does not follow spec CC006 so we need to use the endpoint on traefik integrations.
This PR fixes the error when deploying the module.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library