### PR TITLE
chore: move to channel 6/stable in mongodb

### DIFF
--- a/modules/external/mongodb-k8s/README.md
+++ b/modules/external/mongodb-k8s/README.md
@@ -51,4 +51,4 @@ Please check the available [integration pairs][integration pairs].
 [Terraform]: https://www.terraform.io/
 [Juju]: https://juju.is
 [Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest
-[integration pairs]: https://charmhub.io/mongodb-k8s/integrations?channel=6/edge
+[integration pairs]: https://charmhub.io/mongodb-k8s/integrations?channel=6/stable

--- a/modules/external/mongodb-k8s/variables.tf
+++ b/modules/external/mongodb-k8s/variables.tf
@@ -16,11 +16,11 @@ variable "app_name" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "6/beta"
+  default     = "6/stable"
 }
 
 variable "config" {
-  description = "Additional configuration for the MongoDB. Details about available options can be found at https://charmhub.io/mongodb-k8s/configure?channel=6/beta."
+  description = "Additional configuration for the MongoDB. Details about available options can be found at https://charmhub.io/mongodb-k8s/configurations?channel=6/stable."
   type        = map(string)
   default     = {}
 }

--- a/modules/sdcore-control-plane-k8s/README.md
+++ b/modules/sdcore-control-plane-k8s/README.md
@@ -103,7 +103,7 @@ App                       Version  Status   Scale  Charm                     Cha
 amf                                active       1  sdcore-amf-k8s            1.5/edge        29  10.152.183.161  no       
 ausf                               active       1  sdcore-ausf-k8s           1.5/edge        24  10.152.183.55   no       
 grafana-agent             0.32.1   waiting      1  grafana-agent-k8s         latest/stable   51  10.152.183.124  no       installing agent
-mongodb                            active       1  mongodb-k8s               6/beta          38  10.152.183.204  no       Primary
+mongodb                            active       1  mongodb-k8s               6/stable        61  10.152.183.204  no       Primary
 nms                                active       1  sdcore-nms-k8s            1.5/edge        23  10.152.183.238  no       
 nrf                                active       1  sdcore-nrf-k8s            1.5/edge        30  10.152.183.78   no       
 nssf                               active       1  sdcore-nssf-k8s           1.5/edge        24  10.152.183.215  no       

--- a/modules/sdcore-control-plane-k8s/variables.tf
+++ b/modules/sdcore-control-plane-k8s/variables.tf
@@ -15,7 +15,7 @@ variable "sdcore_channel" {
 variable "mongo_channel" {
   description = "The channel to use when deploying `mongodb-k8s` charm."
   type        = string
-  default     = "6/beta"
+  default     = "6/stable"
 }
 
 variable "grafana_agent_channel" {
@@ -49,7 +49,7 @@ variable "nssf_config" {
 }
 
 variable "mongo_config" {
-  description = "Additional configuration for the MongoDB. Details about available options can be found at https://charmhub.io/mongodb-k8s/configure?channel=6/beta."
+  description = "Additional configuration for the MongoDB. Details about available options can be found at https://charmhub.io/mongodb-k8s/configurations?channel=6/stable."
   type        = map(string)
   default     = {}
 }

--- a/modules/sdcore-k8s/README.md
+++ b/modules/sdcore-k8s/README.md
@@ -104,7 +104,7 @@ App                       Version  Status   Scale  Charm                     Cha
 amf                                active       1  sdcore-amf-k8s            1.5/edge        29  10.152.183.243  no       
 ausf                               active       1  sdcore-ausf-k8s           1.5/edge        24  10.152.183.126  no       
 grafana-agent             0.32.1   waiting      1  grafana-agent-k8s         latest/stable   51  10.152.183.232  no       installing agent
-mongodb                            active       1  mongodb-k8s               6/beta          38  10.152.183.205  no       Primary
+mongodb                            active       1  mongodb-k8s               6/stable        61  10.152.183.205  no       Primary
 nms                                active       1  sdcore-nms-k8s            1.5/edge        23  10.152.183.87   no       
 nrf                                active       1  sdcore-nrf-k8s            1.5/edge        30  10.152.183.27   no       
 nssf                               active       1  sdcore-nssf-k8s           1.5/edge        24  10.152.183.210  no       

--- a/modules/sdcore-k8s/variables.tf
+++ b/modules/sdcore-k8s/variables.tf
@@ -48,10 +48,10 @@ variable "grafana_agent_config" {
 variable "mongo_channel" {
   description = "The channel to use when deploying `mongodb-k8s` charm."
   type        = string
-  default     = "6/beta"
+  default     = "6/stable"
 }
 variable "mongo_config" {
-  description = "Additional configuration for the MongoDB. Details about available options can be found at https://charmhub.io/mongodb-k8s/configure?channel=6/beta."
+  description = "Additional configuration for the MongoDB. Details about available options can be found at https://charmhub.io/mongodb-k8s/configurations?channel=6/stable."
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
# Description

This PR sets the the `6/stable` channel for mongodb charm instead of `6/beta`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library