### PR TITLE
chore: Bumps charms channel to 1.6/edge

### DIFF
--- a/modules/sdcore-control-plane-k8s/README.md
+++ b/modules/sdcore-control-plane-k8s/README.md
@@ -100,19 +100,19 @@ Model     Controller          Cloud/Region        Version  SLA          Timestam
 <model_name>  microk8s-localhost  microk8s/localhost  3.5.4    unsupported  17:03:06+03:00
 
 App                       Version  Status   Scale  Charm                     Channel        Rev  Address         Exposed  Message
-amf                                active       1  sdcore-amf-k8s            1.5/edge        29  10.152.183.161  no       
-ausf                               active       1  sdcore-ausf-k8s           1.5/edge        24  10.152.183.55   no       
+amf                                active       1  sdcore-amf-k8s            1.6/edge        29  10.152.183.161  no       
+ausf                               active       1  sdcore-ausf-k8s           1.6/edge        24  10.152.183.55   no       
 grafana-agent             0.32.1   waiting      1  grafana-agent-k8s         latest/stable   51  10.152.183.124  no       installing agent
 mongodb                            active       1  mongodb-k8s               6/stable        61  10.152.183.204  no       Primary
-nms                                active       1  sdcore-nms-k8s            1.5/edge        23  10.152.183.238  no       
-nrf                                active       1  sdcore-nrf-k8s            1.5/edge        30  10.152.183.78   no       
-nssf                               active       1  sdcore-nssf-k8s           1.5/edge        24  10.152.183.215  no       
-pcf                                active       1  sdcore-pcf-k8s            1.5/edge        26  10.152.183.225  no       
+nms                                active       1  sdcore-nms-k8s            1.6/edge        23  10.152.183.238  no       
+nrf                                active       1  sdcore-nrf-k8s            1.6/edge        30  10.152.183.78   no       
+nssf                               active       1  sdcore-nssf-k8s           1.6/edge        24  10.152.183.215  no       
+pcf                                active       1  sdcore-pcf-k8s            1.6/edge        26  10.152.183.225  no       
 self-signed-certificates           active       1  self-signed-certificates  latest/stable   72  10.152.183.146  no       
-smf                                active       1  sdcore-smf-k8s            1.5/edge        25  10.152.183.29   no       
+smf                                active       1  sdcore-smf-k8s            1.6/edge        25  10.152.183.29   no       
 traefik                   2.10.4   active       1  traefik-k8s               latest/stable  166  10.0.0.10       no       
-udm                                active       1  sdcore-udm-k8s            1.5/edge        23  10.152.183.251  no       
-udr                                active       1  sdcore-udr-k8s            1.5/edge        23  10.152.183.26   no          
+udm                                active       1  sdcore-udm-k8s            1.6/edge        23  10.152.183.251  no       
+udr                                active       1  sdcore-udr-k8s            1.6/edge        23  10.152.183.26   no          
 
 Unit                         Workload  Agent  Address       Ports  Message
 amf/0*                       active    idle   10.1.146.71          

--- a/modules/sdcore-control-plane-k8s/variables.tf
+++ b/modules/sdcore-control-plane-k8s/variables.tf
@@ -9,7 +9,7 @@ variable "model" {
 variable "sdcore_channel" {
   description = "The channel to use when deploying Charmed Aether SD-Core charms."
   type        = string
-  default     = "1.5/edge"
+  default     = "1.6/edge"
 }
 
 variable "mongo_channel" {

--- a/modules/sdcore-k8s/README.md
+++ b/modules/sdcore-k8s/README.md
@@ -101,20 +101,20 @@ Model       Controller          Cloud/Region        Version  SLA          Timest
 <model_name>  microk8s-localhost  microk8s/localhost  3.5.4   unsupported  16:57:40+03:00
 
 App                       Version  Status   Scale  Charm                     Channel        Rev  Address         Exposed  Message
-amf                                active       1  sdcore-amf-k8s            1.5/edge        29  10.152.183.243  no       
-ausf                               active       1  sdcore-ausf-k8s           1.5/edge        24  10.152.183.126  no       
+amf                                active       1  sdcore-amf-k8s            1.6/edge        29  10.152.183.243  no       
+ausf                               active       1  sdcore-ausf-k8s           1.6/edge        24  10.152.183.126  no       
 grafana-agent             0.32.1   waiting      1  grafana-agent-k8s         latest/stable   51  10.152.183.232  no       installing agent
 mongodb                            active       1  mongodb-k8s               6/stable        61  10.152.183.205  no       Primary
-nms                                active       1  sdcore-nms-k8s            1.5/edge        23  10.152.183.87   no       
-nrf                                active       1  sdcore-nrf-k8s            1.5/edge        30  10.152.183.27   no       
-nssf                               active       1  sdcore-nssf-k8s           1.5/edge        24  10.152.183.210  no       
-pcf                                active       1  sdcore-pcf-k8s            1.5/edge        26  10.152.183.64   no       
+nms                                active       1  sdcore-nms-k8s            1.6/edge        23  10.152.183.87   no       
+nrf                                active       1  sdcore-nrf-k8s            1.6/edge        30  10.152.183.27   no       
+nssf                               active       1  sdcore-nssf-k8s           1.6/edge        24  10.152.183.210  no       
+pcf                                active       1  sdcore-pcf-k8s            1.6/edge        26  10.152.183.64   no       
 self-signed-certificates           active       1  self-signed-certificates  latest/stable   72  10.152.183.104  no       
-smf                                active       1  sdcore-smf-k8s            1.5/edge        25  10.152.183.134  no       
+smf                                active       1  sdcore-smf-k8s            1.6/edge        25  10.152.183.134  no       
 traefik                   2.10.4   active       1  traefik-k8s               latest/stable  166  10.0.0.14       no       
-udm                                active       1  sdcore-udm-k8s            1.5/edge        23  10.152.183.165  no       
-udr                                active       1  sdcore-udr-k8s            1.5/edge        23  10.152.183.166  no       
-upf                                active       1  sdcore-upf-k8s            1.5/edge        31  10.152.183.91   no         
+udm                                active       1  sdcore-udm-k8s            1.6/edge        23  10.152.183.165  no       
+udr                                active       1  sdcore-udr-k8s            1.6/edge        23  10.152.183.166  no       
+upf                                active       1  sdcore-upf-k8s            1.6/edge        31  10.152.183.91   no         
 
 Unit                         Workload  Agent  Address       Ports  Message
 amf/0*                       active    idle   10.1.146.108         

--- a/modules/sdcore-k8s/variables.tf
+++ b/modules/sdcore-k8s/variables.tf
@@ -9,7 +9,7 @@ variable "model" {
 variable "sdcore_channel" {
   description = "The channel to use when deploying Charmed Aether SD-Core charms."
   type        = string
-  default     = "1.5/edge"
+  default     = "1.6/edge"
 }
 
 variable "amf_config" {

--- a/modules/sdcore-user-plane-k8s/README.md
+++ b/modules/sdcore-user-plane-k8s/README.md
@@ -102,7 +102,7 @@ Model  Controller          Cloud/Region        Version  SLA          Timestamp
 
 App            Version  Status   Scale  Charm              Channel        Rev  Address         Exposed  Message
 grafana-agent  0.32.1   waiting      1  grafana-agent-k8s  latest/stable   51  10.152.183.231  no       installing agent
-upf                     active       1  sdcore-upf-k8s     1.5/edge        31  10.152.183.100  no       
+upf                     active       1  sdcore-upf-k8s     1.6/edge        31  10.152.183.100  no       
 
 Unit              Workload  Agent  Address      Ports  Message
 grafana-agent/0*  blocked   idle   10.1.146.98         send-remote-write: off, grafana-cloud-config: off

--- a/modules/sdcore-user-plane-k8s/variables.tf
+++ b/modules/sdcore-user-plane-k8s/variables.tf
@@ -10,7 +10,7 @@ variable "model" {
 variable "upf_channel" {
   description = "The channel to use when deploying `sdcore-upf-k8s` charm."
   type        = string
-  default     = "1.5/edge"
+  default     = "1.6/edge"
 }
 
 variable "grafana_agent_channel" {


### PR DESCRIPTION
# Description

Bumps charms channel to `1.6/edge` after creation of the `v1.5` release branch

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library