### PR TITLE
fix: Adds missing amf_resources variable

### DIFF
--- a/modules/sdcore-k8s/variables.tf
+++ b/modules/sdcore-k8s/variables.tf
@@ -18,6 +18,12 @@ variable "amf_config" {
   default     = {}
 }
 
+variable "amf_resources" {
+  description = "Resources to use with the application. Details about available options can be found at https://charmhub.io/sdcore-amf-k8s-operator/configure."
+  type        = map(string)
+  default     = {}
+}
+
 variable "amf_revision" {
   description = "Revision number of the AMF charm"
   type        = number


### PR DESCRIPTION
# Description

Adds missing amf_resources variable

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library