### PR TITLE
chore: Removes nssf_config variable

### DIFF
--- a/modules/sdcore-control-plane-k8s/main.tf
+++ b/modules/sdcore-control-plane-k8s/main.tf
@@ -42,7 +42,6 @@ module "nssf" {
   source    = "git::https://github.com/canonical/sdcore-nssf-k8s-operator//terraform?ref=v1.5"
   model     = data.juju_model.sdcore.name
   channel   = var.sdcore_channel
-  config    = var.nssf_config
   revision  = var.nssf_revision
   resources = var.nssf_resources
 }

--- a/modules/sdcore-control-plane-k8s/variables.tf
+++ b/modules/sdcore-control-plane-k8s/variables.tf
@@ -90,12 +90,6 @@ variable "nrf_revision" {
   default     = null
 }
 
-variable "nssf_config" {
-  description = "Application config for the NSSF. Details about available options can be found at https://charmhub.io/sdcore-nssf-k8s-operator/configure."
-  type        = map(string)
-  default     = {}
-}
-
 variable "nssf_resources" {
   description = "Resources to use with the application. Details about available options can be found at https://charmhub.io/sdcore-nssf-k8s-operator/configure."
   type        = map(string)

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -42,7 +42,6 @@ module "nssf" {
   source    = "git::https://github.com/canonical/sdcore-nssf-k8s-operator//terraform?ref=v1.5"
   model     = data.juju_model.sdcore.name
   channel   = var.sdcore_channel
-  config    = var.nssf_config
   revision  = var.nssf_revision
   resources = var.nssf_resources
 }

--- a/modules/sdcore-k8s/variables.tf
+++ b/modules/sdcore-k8s/variables.tf
@@ -66,12 +66,6 @@ variable "nrf_revision" {
   default     = null
 }
 
-variable "nssf_config" {
-  description = "Application config for the NSSF. Details about available options can be found at https://charmhub.io/sdcore-nssf-k8s-operator/configure."
-  type        = map(string)
-  default     = {}
-}
-
 variable "nssf_resources" {
   description = "Resources to use with the application. Details about available options can be found at https://charmhub.io/sdcore-nssf-k8s-operator/configure."
   type        = map(string)


### PR DESCRIPTION
# Description

Removes `nssf_config` variable
This PR follows https://github.com/canonical/sdcore-nssf-k8s-operator/pull/369

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library