### PR TITLE
feat: Replaces fiveg_gnb_identity with fiveg_core_gnb

### DIFF
--- a/modules/sdcore-control-plane-k8s/main.tf
+++ b/modules/sdcore-control-plane-k8s/main.tf
@@ -841,3 +841,9 @@ resource "juju_offer" "amf-fiveg-n2" {
   application_name = module.amf.app_name
   endpoint         = module.amf.provides.fiveg_n2
 }
+
+resource "juju_offer" "nms-fiveg-core-gnb" {
+  application_name = data.juju_model.sdcore.name
+  endpoint         = module.nms.app_name
+  model            = module.nms.provides.fiveg_core_gnb
+}

--- a/modules/sdcore-control-plane-k8s/outputs.tf
+++ b/modules/sdcore-control-plane-k8s/outputs.tf
@@ -8,6 +8,11 @@ output "amf_fiveg_n2_offer_url" {
   value       = juju_offer.amf-fiveg-n2.url
 }
 
+output "nms_fiveg_core_gnb_offer_url" {
+  description = "NMS `fiveg_core_gnb` offer."
+  value       = juju_offer.nms-fiveg-core-gnb.url
+}
+
 # Outputs required to consume external offers
 
 output "nms_app_name" {
@@ -17,10 +22,6 @@ output "nms_app_name" {
 output "fiveg_n4_endpoint" {
   description = "Name of the endpoint to integrate with fiveg_n4 interface."
   value       = module.nms.requires.fiveg_n4
-}
-output "fiveg_gnb_identity_endpoint" {
-  description = "Name of the endpoint to integrate with fiveg_gnb_identity interface."
-  value       = module.nms.requires.fiveg_gnb_identity
 }
 
 output "grafana_agent_app_name" {

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -895,6 +895,12 @@ resource "juju_offer" "amf-fiveg-n2" {
   endpoint         = module.amf.provides.fiveg_n2
 }
 
+resource "juju_offer" "nms-fiveg-core-gnb" {
+  application_name = data.juju_model.sdcore.name
+  endpoint         = module.nms.app_name
+  model            = module.nms.provides.fiveg_core_gnb
+}
+
 resource "juju_offer" "upf-fiveg-n3" {
   model            = data.juju_model.sdcore.name
   application_name = module.upf.app_name

--- a/modules/sdcore-k8s/outputs.tf
+++ b/modules/sdcore-k8s/outputs.tf
@@ -8,21 +8,17 @@ output "amf_fiveg_n2_offer_url" {
   value       = juju_offer.amf-fiveg-n2.url
 }
 
+output "nms_fiveg_core_gnb_offer_url" {
+  description = "NMS `fiveg_core_gnb` offer."
+  value       = juju_offer.nms-fiveg-core-gnb.url
+}
+
 output "upf_fiveg_n3_offer_url" {
   description = "UPF `fiveg_n3` offer."
   value       = juju_offer.upf-fiveg-n3.url
 }
 
 # Outputs required to consume external offers
-
-output "nms_app_name" {
-  description = "Name of the deployed NMS application."
-  value       = module.nms.app_name
-}
-output "fiveg_gnb_identity_endpoint" {
-  description = "Name of the endpoint to integrate with fiveg_gnb_identity interface."
-  value       = module.nms.requires.fiveg_gnb_identity
-}
 
 output "grafana_agent_app_name" {
   description = "Name of the deployed Grafana Agent application."


### PR DESCRIPTION
# Description

Replaces `fiveg_gnb_identity` with `fiveg_core_gnb`
This PR is part of [TELCO-1450: Implement mechanism orchestrating network configuration between the Core and the RAN](https://warthogs.atlassian.net/browse/TELCO-1450)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library