### PR TITLE
feat: Bump NMS for fiveg_core_gnb integration

### DIFF
--- a/modules/sdcore-control-plane-k8s/main.tf
+++ b/modules/sdcore-control-plane-k8s/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 data "juju_model" "sdcore" {
@@ -25,7 +25,7 @@ module "ausf" {
 module "nms" {
   source    = "git::https://github.com/canonical/sdcore-nms-k8s-operator//terraform?ref=v1.5"
   model     = data.juju_model.sdcore.name
-  channel   = var.sdcore_channel
+  channel   = var.nms_channel
   revision  = var.nms_revision
   resources = var.nms_resources
 }

--- a/modules/sdcore-control-plane-k8s/outputs.tf
+++ b/modules/sdcore-control-plane-k8s/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Integration offers for external systems
@@ -18,9 +18,9 @@ output "fiveg_n4_endpoint" {
   description = "Name of the endpoint to integrate with fiveg_n4 interface."
   value       = module.nms.requires.fiveg_n4
 }
-output "fiveg_gnb_identity_endpoint" {
-  description = "Name of the endpoint to integrate with fiveg_gnb_identity interface."
-  value       = module.nms.requires.fiveg_gnb_identity
+output "fiveg_core_gnb_endpoint" {
+  description = "Name of the endpoint to integrate with fiveg_core_gnb interface."
+  value       = module.nms.provides.fiveg_core_gnb
 }
 
 output "grafana_agent_app_name" {

--- a/modules/sdcore-control-plane-k8s/variables.tf
+++ b/modules/sdcore-control-plane-k8s/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 variable "model" {
@@ -64,6 +64,12 @@ variable "ausf_revision" {
   description = "Revision number of the AUSF charm"
   type        = number
   default     = null
+}
+
+variable "nms_channel" {
+  description = "The channel to use when deploying the NMS charm."
+  type        = string
+  default     = "1.5/stable"
 }
 
 variable "nms_resources" {

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 data "juju_model" "sdcore" {
@@ -25,7 +25,7 @@ module "ausf" {
 module "nms" {
   source    = "git::https://github.com/canonical/sdcore-nms-k8s-operator//terraform?ref=v1.5"
   model     = data.juju_model.sdcore.name
-  channel   = var.sdcore_channel
+  channel   = var.nms_channel
   revision  = var.nms_revision
   resources = var.nms_resources
 }

--- a/modules/sdcore-k8s/outputs.tf
+++ b/modules/sdcore-k8s/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Integration offers for external systems
@@ -19,9 +19,9 @@ output "nms_app_name" {
   description = "Name of the deployed NMS application."
   value       = module.nms.app_name
 }
-output "fiveg_gnb_identity_endpoint" {
-  description = "Name of the endpoint to integrate with fiveg_gnb_identity interface."
-  value       = module.nms.requires.fiveg_gnb_identity
+output "fiveg_core_gnb_endpoint" {
+  description = "Name of the endpoint to integrate with fiveg_core_gnb interface."
+  value       = module.nms.provides.fiveg_core_gnb
 }
 
 output "grafana_agent_app_name" {

--- a/modules/sdcore-k8s/variables.tf
+++ b/modules/sdcore-k8s/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 variable "model" {
@@ -40,6 +40,12 @@ variable "ausf_revision" {
   description = "Revision number of the AUSF charm"
   type        = number
   default     = null
+}
+
+variable "nms_channel" {
+  description = "The channel to use when deploying the NMS charm."
+  type        = string
+  default     = "1.5/stable"
 }
 
 variable "nms_resources" {


### PR DESCRIPTION
# Description

This bumps the version of the NMS to get the `fiveg_core_gnb` integration to stay compatible with Charmed OAI RAN.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library