### PR TITLE
feat: Exposes NRF config

### DIFF
--- a/modules/sdcore-control-plane-k8s/main.tf
+++ b/modules/sdcore-control-plane-k8s/main.tf
@@ -34,6 +34,7 @@ module "nrf" {
   source    = "git::https://github.com/canonical/sdcore-nrf-k8s-operator//terraform"
   model     = data.juju_model.sdcore.name
   channel   = var.sdcore_channel
+  config    = var.nrf_config
   revision  = var.nrf_revision
   resources = var.nrf_resources
 }

--- a/modules/sdcore-control-plane-k8s/variables.tf
+++ b/modules/sdcore-control-plane-k8s/variables.tf
@@ -78,6 +78,12 @@ variable "nms_revision" {
   default     = null
 }
 
+variable "nrf_config" {
+  description = "Application config for the NRF. Details about available options can be found at https://charmhub.io/sdcore-nrf-k8s-operator/configure."
+  type        = map(string)
+  default     = {}
+}
+
 variable "nrf_resources" {
   description = "Resources to use with the application. Details about available options can be found at https://charmhub.io/sdcore-nrf-k8s-operator/configure."
   type        = map(string)

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -34,6 +34,7 @@ module "nrf" {
   source    = "git::https://github.com/canonical/sdcore-nrf-k8s-operator//terraform"
   model     = data.juju_model.sdcore.name
   channel   = var.sdcore_channel
+  config    = var.nrf_config
   revision  = var.nrf_revision
   resources = var.nrf_resources
 }

--- a/modules/sdcore-k8s/variables.tf
+++ b/modules/sdcore-k8s/variables.tf
@@ -54,6 +54,12 @@ variable "nms_revision" {
   default     = null
 }
 
+variable "nrf_config" {
+  description = "Application config for the NRF. Details about available options can be found at https://charmhub.io/sdcore-nrf-k8s-operator/configure."
+  type        = map(string)
+  default     = {}
+}
+
 variable "nrf_resources" {
   description = "Resources to use with the application. Details about available options can be found at https://charmhub.io/sdcore-nrf-k8s-operator/configure."
   type        = map(string)


### PR DESCRIPTION
# Description

Follows up on [NRF #462](https://github.com/canonical/sdcore-nrf-k8s-operator/pull/462)
Exposes `nrf_config` to allow setting `log-level`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library