### PR TITLE
chore: use self-signed-certificates from 1/stable channel

### DIFF
--- a/modules/sdcore-control-plane-k8s/README.md
+++ b/modules/sdcore-control-plane-k8s/README.md
@@ -108,7 +108,7 @@ nms                                active       1  sdcore-nms-k8s            1.6
 nrf                                active       1  sdcore-nrf-k8s            1.6/edge        30  10.152.183.78   no       
 nssf                               active       1  sdcore-nssf-k8s           1.6/edge        24  10.152.183.215  no       
 pcf                                active       1  sdcore-pcf-k8s            1.6/edge        26  10.152.183.225  no       
-self-signed-certificates           active       1  self-signed-certificates  latest/stable   72  10.152.183.146  no       
+self-signed-certificates           active       1  self-signed-certificates  1/stable        72  10.152.183.146  no       
 smf                                active       1  sdcore-smf-k8s            1.6/edge        25  10.152.183.29   no       
 traefik                   2.10.4   active       1  traefik-k8s               latest/stable  166  10.0.0.10       no       
 udm                                active       1  sdcore-udm-k8s            1.6/edge        23  10.152.183.251  no       

--- a/modules/sdcore-control-plane-k8s/variables.tf
+++ b/modules/sdcore-control-plane-k8s/variables.tf
@@ -27,7 +27,7 @@ variable "grafana_agent_channel" {
 variable "self_signed_certificates_channel" {
   description = "The channel to use when deploying `self-signed-certificates-operator` charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 
 variable "traefik_channel" {

--- a/modules/sdcore-k8s/README.md
+++ b/modules/sdcore-k8s/README.md
@@ -109,7 +109,7 @@ nms                                active       1  sdcore-nms-k8s            1.6
 nrf                                active       1  sdcore-nrf-k8s            1.6/edge        30  10.152.183.27   no       
 nssf                               active       1  sdcore-nssf-k8s           1.6/edge        24  10.152.183.210  no       
 pcf                                active       1  sdcore-pcf-k8s            1.6/edge        26  10.152.183.64   no       
-self-signed-certificates           active       1  self-signed-certificates  latest/stable   72  10.152.183.104  no       
+self-signed-certificates           active       1  self-signed-certificates  1/stable        72  10.152.183.104  no       
 smf                                active       1  sdcore-smf-k8s            1.6/edge        25  10.152.183.134  no       
 traefik                   2.10.4   active       1  traefik-k8s               latest/stable  166  10.0.0.14       no       
 udm                                active       1  sdcore-udm-k8s            1.6/edge        23  10.152.183.165  no       

--- a/modules/sdcore-k8s/variables.tf
+++ b/modules/sdcore-k8s/variables.tf
@@ -223,7 +223,7 @@ variable "mongo_config" {
 variable "self_signed_certificates_channel" {
   description = "The channel to use when deploying `self-signed-certificates-operator` charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 variable "self_signed_certificates_config" {
   description = "Additional configuration for the Self-Signed-Certificates. Details about available options can be found at https://charmhub.io/self-signed-certificates-operator/configure."


### PR DESCRIPTION
# Description

Deploy SD-Core alongside self-signed-certificates from the `1/stable` channel, which is the latest stable release of the charm.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library