### PR TITLE
fix: Pins the revision of self-signed-certificates to latest working

### DIFF
--- a/modules/sdcore-control-plane-k8s/main.tf
+++ b/modules/sdcore-control-plane-k8s/main.tf
@@ -101,11 +101,12 @@ module "grafana-agent" {
 }
 
 module "self-signed-certificates" {
-  source  = "git::https://github.com/canonical/self-signed-certificates-operator//terraform"
-  model   = data.juju_model.sdcore.name
-  channel = var.self_signed_certificates_channel
-  base    = "ubuntu@24.04"
-  config  = var.self_signed_certificates_config
+  source   = "git::https://github.com/canonical/self-signed-certificates-operator//terraform"
+  model    = data.juju_model.sdcore.name
+  channel  = var.self_signed_certificates_channel
+  base     = "ubuntu@24.04"
+  config   = var.self_signed_certificates_config
+  revision = 308  # Workaround for https://github.com/canonical/charmed-aether-sd-core/issues/119
 }
 
 module "traefik" {

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -101,11 +101,12 @@ module "grafana-agent" {
 }
 
 module "self-signed-certificates" {
-  source  = "git::https://github.com/canonical/self-signed-certificates-operator//terraform"
-  model   = data.juju_model.sdcore.name
-  channel = var.self_signed_certificates_channel
-  base    = "ubuntu@24.04"
-  config  = var.self_signed_certificates_config
+  source   = "git::https://github.com/canonical/self-signed-certificates-operator//terraform"
+  model    = data.juju_model.sdcore.name
+  channel  = var.self_signed_certificates_channel
+  base     = "ubuntu@24.04"
+  config   = var.self_signed_certificates_config
+  revision = 308  # Workaround for https://github.com/canonical/charmed-aether-sd-core/issues/119
 }
 
 module "traefik" {


### PR DESCRIPTION
# Description

This PR adds a workaround for
https://github.com/canonical/charmed-aether-sd-core/issues/119
and related https://github.com/canonical/traefik-k8s-operator/issues/491

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library