### PR TITLE
fix: Sets grafana-agent channel to 1/stable

### DIFF
--- a/modules/sdcore-control-plane-k8s/variables.tf
+++ b/modules/sdcore-control-plane-k8s/variables.tf
@@ -21,7 +21,7 @@ variable "mongo_channel" {
 variable "grafana_agent_channel" {
   description = "The channel to use when deploying `grafana-agent-k8s` charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 
 variable "self_signed_certificates_channel" {

--- a/modules/sdcore-k8s/variables.tf
+++ b/modules/sdcore-k8s/variables.tf
@@ -197,7 +197,7 @@ variable "upf_revision" {
 variable "grafana_agent_channel" {
   description = "The channel to use when deploying `grafana-agent-k8s` charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 variable "grafana_agent_config" {
   description = "Additional configuration for the Grafana Agent. Details about available options can be found at https://charmhub.io/grafana-agent-k8s/configure."

--- a/modules/sdcore-user-plane-k8s/variables.tf
+++ b/modules/sdcore-user-plane-k8s/variables.tf
@@ -16,7 +16,7 @@ variable "upf_channel" {
 variable "grafana_agent_channel" {
   description = "The channel to use when deploying `grafana-agent-k8s` charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 
 variable "upf_config" {


### PR DESCRIPTION
# Description

This PR changes the default channel for grafana-agent from `latest/stable` to `1/stable`. The former doesn't exist anymore.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library