### PR TITLE
fix: set default channels to 1/stable for COS charms

### DIFF
--- a/modules/external/alertmanager-k8s/variables.tf
+++ b/modules/external/alertmanager-k8s/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "Channel to use when deploying a charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 
 variable "config" {

--- a/modules/external/catalogue-k8s/variables.tf
+++ b/modules/external/catalogue-k8s/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 
 variable "config" {

--- a/modules/external/cos-configuration-k8s/variables.tf
+++ b/modules/external/cos-configuration-k8s/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 
 variable "config" {

--- a/modules/external/cos-lite/variables.tf
+++ b/modules/external/cos-lite/variables.tf
@@ -123,7 +123,7 @@ variable "traefik_app_name" {
 variable "traefik_channel" {
   description = "The channel to use when deploying Traefik charm."
   type        = string
-  default     = "1/stable"
+  default     = "latest/stable"
 }
 variable "traefik_config" {
   description = "Traefik config. Details about available options can be found at https://charmhub.io/traefik-k8s/configure."

--- a/modules/external/cos-lite/variables.tf
+++ b/modules/external/cos-lite/variables.tf
@@ -123,7 +123,7 @@ variable "traefik_app_name" {
 variable "traefik_channel" {
   description = "The channel to use when deploying Traefik charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 variable "traefik_config" {
   description = "Traefik config. Details about available options can be found at https://charmhub.io/traefik-k8s/configure."

--- a/modules/external/grafana-agent-k8s/variables.tf
+++ b/modules/external/grafana-agent-k8s/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 
 variable "config" {

--- a/modules/external/grafana-k8s/variables.tf
+++ b/modules/external/grafana-k8s/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "Channel to use when deploying a charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 
 variable "config" {

--- a/modules/external/loki-k8s/variables.tf
+++ b/modules/external/loki-k8s/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 
 variable "config" {

--- a/modules/sdcore-control-plane-k8s/README.md
+++ b/modules/sdcore-control-plane-k8s/README.md
@@ -102,7 +102,7 @@ Model     Controller          Cloud/Region        Version  SLA          Timestam
 App                       Version  Status   Scale  Charm                     Channel        Rev  Address         Exposed  Message
 amf                                active       1  sdcore-amf-k8s            1.6/edge        29  10.152.183.161  no       
 ausf                               active       1  sdcore-ausf-k8s           1.6/edge        24  10.152.183.55   no       
-grafana-agent             0.32.1   waiting      1  grafana-agent-k8s         latest/stable   51  10.152.183.124  no       installing agent
+grafana-agent             0.32.1   waiting      1  grafana-agent-k8s         1/stable        51  10.152.183.124  no       installing agent
 mongodb                            active       1  mongodb-k8s               6/stable        61  10.152.183.204  no       Primary
 nms                                active       1  sdcore-nms-k8s            1.6/edge        23  10.152.183.238  no       
 nrf                                active       1  sdcore-nrf-k8s            1.6/edge        30  10.152.183.78   no       

--- a/modules/sdcore-control-plane-k8s/README.md
+++ b/modules/sdcore-control-plane-k8s/README.md
@@ -102,7 +102,7 @@ Model     Controller          Cloud/Region        Version  SLA          Timestam
 App                       Version  Status   Scale  Charm                     Channel        Rev  Address         Exposed  Message
 amf                                active       1  sdcore-amf-k8s            1.6/edge        29  10.152.183.161  no       
 ausf                               active       1  sdcore-ausf-k8s           1.6/edge        24  10.152.183.55   no       
-grafana-agent             0.32.1   waiting      1  grafana-agent-k8s         1/stable        51  10.152.183.124  no       installing agent
+grafana-agent             0.32.1   waiting      1  grafana-agent-k8s         1/stable       115  10.152.183.124  no       installing agent
 mongodb                            active       1  mongodb-k8s               6/stable        61  10.152.183.204  no       Primary
 nms                                active       1  sdcore-nms-k8s            1.6/edge        23  10.152.183.238  no       
 nrf                                active       1  sdcore-nrf-k8s            1.6/edge        30  10.152.183.78   no       

--- a/modules/sdcore-k8s/README.md
+++ b/modules/sdcore-k8s/README.md
@@ -103,7 +103,7 @@ Model       Controller          Cloud/Region        Version  SLA          Timest
 App                       Version  Status   Scale  Charm                     Channel        Rev  Address         Exposed  Message
 amf                                active       1  sdcore-amf-k8s            1.6/edge        29  10.152.183.243  no       
 ausf                               active       1  sdcore-ausf-k8s           1.6/edge        24  10.152.183.126  no       
-grafana-agent             0.32.1   waiting      1  grafana-agent-k8s         latest/stable   51  10.152.183.232  no       installing agent
+grafana-agent             0.32.1   waiting      1  grafana-agent-k8s         1/stable        51  10.152.183.232  no       installing agent
 mongodb                            active       1  mongodb-k8s               6/stable        61  10.152.183.205  no       Primary
 nms                                active       1  sdcore-nms-k8s            1.6/edge        23  10.152.183.87   no       
 nrf                                active       1  sdcore-nrf-k8s            1.6/edge        30  10.152.183.27   no       

--- a/modules/sdcore-user-plane-k8s/README.md
+++ b/modules/sdcore-user-plane-k8s/README.md
@@ -101,7 +101,7 @@ Model  Controller          Cloud/Region        Version  SLA          Timestamp
 <model_name>   microk8s-localhost  microk8s/localhost  3.5.4    unsupported  17:04:33+03:00
 
 App            Version  Status   Scale  Charm              Channel        Rev  Address         Exposed  Message
-grafana-agent  0.32.1   waiting      1  grafana-agent-k8s  latest/stable   51  10.152.183.231  no       installing agent
+grafana-agent  0.32.1   waiting      1  grafana-agent-k8s  1/stable        51  10.152.183.231  no       installing agent
 upf                     active       1  sdcore-upf-k8s     1.6/edge        31  10.152.183.100  no       
 
 Unit              Workload  Agent  Address      Ports  Message


### PR DESCRIPTION
# Description

COS-lite charms have been released to `1/stable` channel instead of latest/stable. This PR updates the default channel values for:

- Alertmanager
- Catalogue
- COS configuration
- Grafana
- Grafana agent
- Loki
- Prometheus

This PR is a continuation of https://github.com/canonical/terraform-juju-sdcore/pull/103

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library