### PR TITLE
fix: Updates juju_offers to match the new schema

### DIFF
--- a/modules/external/cos-lite/main.tf
+++ b/modules/external/cos-lite/main.tf
@@ -396,11 +396,11 @@ resource "juju_integration" "traefik-metrics" {
 resource "juju_offer" "prometheus-remote-write" {
   model            = var.model_name
   application_name = module.prometheus.app_name
-  endpoint         = module.prometheus.receive_remote_write_endpoint
+  endpoints        = [module.prometheus.receive_remote_write_endpoint]
 }
 
 resource "juju_offer" "loki-logging" {
   model            = var.model_name
   application_name = module.loki.app_name
-  endpoint         = module.loki.logging_endpoint
+  endpoints        = [module.loki.logging_endpoint]
 }

--- a/modules/external/cos-lite/versions.tf
+++ b/modules/external/cos-lite/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.11.0"
+      version = ">= 0.20.0"
     }
   }
 }

--- a/modules/sdcore-control-plane-k8s/main.tf
+++ b/modules/sdcore-control-plane-k8s/main.tf
@@ -849,11 +849,11 @@ resource "juju_integration" "nms-logging" {
 resource "juju_offer" "amf-fiveg-n2" {
   model            = data.juju_model.sdcore.name
   application_name = module.amf.app_name
-  endpoint         = module.amf.provides.fiveg_n2
+  endpoints        = [module.amf.provides.fiveg_n2]
 }
 
 resource "juju_offer" "nms-fiveg-core-gnb" {
   model            = data.juju_model.sdcore.name
   application_name = module.nms.app_name
-  endpoint         = module.nms.provides.fiveg_core_gnb
+  endpoints        = [module.nms.provides.fiveg_core_gnb]
 }

--- a/modules/sdcore-control-plane-k8s/versions.tf
+++ b/modules/sdcore-control-plane-k8s/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.12.0"
+      version = ">= 0.20.0"
     }
   }
 }

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -902,17 +902,17 @@ resource "juju_integration" "upf-nms" {
 resource "juju_offer" "amf-fiveg-n2" {
   model            = data.juju_model.sdcore.name
   application_name = module.amf.app_name
-  endpoint         = module.amf.provides.fiveg_n2
+  endpoints        = [module.amf.provides.fiveg_n2]
 }
 
 resource "juju_offer" "nms-fiveg-core-gnb" {
   model            = data.juju_model.sdcore.name
   application_name = module.nms.app_name
-  endpoint         = module.nms.provides.fiveg_core_gnb
+  endpoints        = [module.nms.provides.fiveg_core_gnb]
 }
 
 resource "juju_offer" "upf-fiveg-n3" {
   model            = data.juju_model.sdcore.name
   application_name = module.upf.app_name
-  endpoint         = module.upf.provides.fiveg_n3
+  endpoints        = [module.upf.provides.fiveg_n3]
 }

--- a/modules/sdcore-k8s/versions.tf
+++ b/modules/sdcore-k8s/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.12.0"
+      version = ">= 0.20.0"
     }
   }
 }

--- a/modules/sdcore-user-plane-k8s/main.tf
+++ b/modules/sdcore-user-plane-k8s/main.tf
@@ -58,13 +58,13 @@ resource "juju_integration" "upf-logging" {
 resource "juju_offer" "upf-fiveg-n3" {
   model            = data.juju_model.sdcore_upf.name
   application_name = module.upf.app_name
-  endpoint         = module.upf.provides.fiveg_n3
+  endpoints        = [module.upf.provides.fiveg_n3]
   name             = "upf-fiveg-n3"
 }
 
 resource "juju_offer" "upf-fiveg-n4" {
   model            = data.juju_model.sdcore_upf.name
   application_name = module.upf.app_name
-  endpoint         = module.upf.provides.fiveg_n4
+  endpoints        = [module.upf.provides.fiveg_n4]
   name             = "upf-fiveg-n4"
 }

--- a/modules/sdcore-user-plane-k8s/versions.tf
+++ b/modules/sdcore-user-plane-k8s/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.12.0"
+      version = ">= 0.20.0"
     }
   }
 }


### PR DESCRIPTION
# Description

This PR adjusts our TF modules to the latest `juju_offer` schema introduced in Juju TF provider `v0.20.0`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library